### PR TITLE
Hack to fix duplication issue before Godot 4.3.

### DIFF
--- a/src/Tree3D.h
+++ b/src/Tree3D.h
@@ -33,6 +33,7 @@ public:
 	Tree3D();
 	~Tree3D();
 
+	void _enter_tree() override;
 	void _process(double delta) override;
 
 	void set_seed(int seed);


### PR DESCRIPTION
To fix duplication issue for earler versions. 

A patch of [#15](https://github.com/JekSun97/gdTree3D/pull/15).