### PR TITLE
Fix two major plugin bugs! (Finally).

### DIFF
--- a/src/Tree3D.cpp
+++ b/src/Tree3D.cpp
@@ -88,22 +88,13 @@ void Tree3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material_twig", PROPERTY_HINT_RESOURCE_TYPE, "StandardMaterial3D,ORMMaterial3D,ShaderMaterial"), "set_material_twig", "get_material_twig");
 }
 
-// HACK!! To fix duplication issue before Godot 4.3.
-static const StringName get_hack_meta_identifier(){
-	static StringName ret = "_Tree3DHackOwner_";
-	return ret;
-}
 
 Tree3D::Tree3D() {
 	trunk_inst = memnew(MeshInstance3D);
 	twig_inst = memnew(MeshInstance3D);	
-	this->add_child(trunk_inst);
-	this->add_child(twig_inst);
+	this->add_child(trunk_inst, false, Node::INTERNAL_MODE_FRONT);
+    this->add_child(twig_inst, false, Node::INTERNAL_MODE_FRONT);
 	UpdateAllMeshes();
-
-	// HACK!! To fix duplication issue before Godot 4.3.
-	trunk_inst->set_meta(get_hack_meta_identifier(), this);
-	twig_inst->set_meta(get_hack_meta_identifier(), this);
 }
 
 Tree3D::~Tree3D() {
@@ -111,30 +102,13 @@ Tree3D::~Tree3D() {
 }
 
 void Tree3D::_enter_tree() {
-	// HACK!! To fix duplication issue before Godot 4.3.
-	TypedArray<Node> children = get_children(true);
-	for (int i =0; i < children.size(); ++i) {
-		Node *node = cast_to<MeshInstance3D>(children[i]);
-		if (node->has_meta(get_hack_meta_identifier()) && cast_to<Node>(node->get_meta(get_hack_meta_identifier())) != this) {
-			remove_child(node);
-			node->queue_free();
-		}
-	}
 }
 
 void Tree3D::_process(double delta) {
 }
 
 void Tree3D::_exit_tree() {
-	//godot::UtilityFunctions::print("Tree3D exit");
-	remove_child(trunk_inst);
-	trunk_inst=nullptr;
-	if(twig_inst)
-	{
-	remove_child(twig_inst);
-	twig_inst=nullptr;
-	}
-	
+
 }
 
 
@@ -190,20 +164,23 @@ float Tree3D::get_twig_scale() {
 }
 
 void Tree3D::set_twig_enable(bool value) {
-	if (value)
+if (value)
 	{
-	twig_inst = memnew(MeshInstance3D);	
-	this->add_child(twig_inst);
-	tree.generate();
-	UpdateMeshTwig();
+		if (!twig_inst) {
+            twig_inst = memnew(MeshInstance3D);	
+            this->add_child(twig_inst, false, Node::INTERNAL_MODE_FRONT);
+        }
+        tree.generate();
+        UpdateMeshTwig();
 	}
 	else
 	{
-		remove_child(twig_inst);
-		twig_inst=nullptr;
+		if (twig_inst) {
+            twig_inst->queue_free();
+            twig_inst = nullptr;
+        }
 	}
-	_twig_enable=value;
-//twig_inst->set_visible(value);
+	_twig_enable = value;
 }	
 
 bool Tree3D::get_twig_enable() {


### PR DESCRIPTION
This fixes two major issues with the plugin that were holding it back!

1. Fixed a bug that caused Godot to crash when switching between scene tabs (#13).
2. Fixed an issue when duplicating a Tree3D node that created a ghost mesh (#1).